### PR TITLE
Automatically update lock file in CI for PRs only

### DIFF
--- a/.github/actions/yarn-nm-install/action.yml
+++ b/.github/actions/yarn-nm-install/action.yml
@@ -45,7 +45,11 @@ inputs:
   enable-corepack:
     description: "Enable corepack"
     required: false
-    default: "false"
+    default: "true"
+  prevent-lock-update:
+    description: "Prevent yarn.lock update"
+    required: false
+    default: "true"
 
 runs:
   using: "composite"
@@ -93,10 +97,24 @@ runs:
         path: ${{ inputs.cwd }}/.yarn/ci-cache
         key: yarn-install-state-cache-${{ inputs.cache-prefix }}-${{ runner.os }}-${{ steps.yarn-config.outputs.CURRENT_NODE_VERSION }}-${{ steps.yarn-config.outputs.CURRENT_BRANCH }}-${{ hashFiles(format('{0}/yarn.lock', inputs.cwd), format('{0}/.yarnrc.yml', inputs.cwd)) }}
 
-    - name: 📥 Install dependencies
+    - name: 📥 Install dependencies with prevent lock update
+      if: inputs.prevent-lock-update == 'true'
       shell: bash
       working-directory: ${{ inputs.cwd }}
       run: yarn install --immutable --inline-builds
+      env:
+        # Overrides/align yarnrc.yml options (v3, v4) for a CI context
+        YARN_ENABLE_GLOBAL_CACHE: "false" # Use local cache folder to keep downloaded archives
+        YARN_NM_MODE: "hardlinks-local" # Reduce node_modules size
+        YARN_INSTALL_STATE_PATH: ".yarn/ci-cache/install-state.gz" # Might speed up resolution step when node_modules present
+        # Other environment variables
+        HUSKY: "0" # By default do not run HUSKY install
+
+    - name: 📥 Install dependencies allow lock update
+      if: inputs.prevent-lock-update == 'false'
+      shell: bash
+      working-directory: ${{ inputs.cwd }}
+      run: yarn install --mode update-lockfile
       env:
         # Overrides/align yarnrc.yml options (v3, v4) for a CI context
         YARN_ENABLE_GLOBAL_CACHE: "false" # Use local cache folder to keep downloaded archives

--- a/.github/workflows/test-release-sync.yaml
+++ b/.github/workflows/test-release-sync.yaml
@@ -21,6 +21,7 @@ jobs:
       - name: "Checkout"
         uses: "actions/checkout@v3"
         with:
+          # use branch name instead of triggering ref:
           ref: ${{ github.head_ref }}
           fetch-depth: 2
 
@@ -55,6 +56,8 @@ jobs:
     steps:
       - name: "Checkout"
         uses: "actions/checkout@v3"
+        with:
+          ref: ${{ needs.update-lock-file.outputs.VERIFIED_LOCK_COMMIT }}
 
       - name: "Setup Node"
         uses: "actions/setup-node@v3"
@@ -101,6 +104,8 @@ jobs:
     steps:
       - name: "Checkout"
         uses: "actions/checkout@v3"
+        with:
+          ref: ${{ needs.update-lock-file.outputs.VERIFIED_LOCK_COMMIT }}
 
       - name: "Setup Node"
         uses: "actions/setup-node@v3"

--- a/.github/workflows/test-release-sync.yaml
+++ b/.github/workflows/test-release-sync.yaml
@@ -21,7 +21,7 @@ jobs:
       - name: "Checkout"
         uses: "actions/checkout@v3"
         with:
-          # use branch name instead of triggering ref:
+          # use branch name instead of triggering ref so we can commit to the PR branch:
           ref: ${{ github.head_ref }}
           fetch-depth: 2
 

--- a/.github/workflows/test-release-sync.yaml
+++ b/.github/workflows/test-release-sync.yaml
@@ -27,12 +27,12 @@ jobs:
       - name: "Setup Node"
         uses: "actions/setup-node@v3"
         with:
-          node-version-file: "js/.nvmrc"
+          node-version-file: ".nvmrc"
 
       - name: "Install dependencies with yarn cache"
         uses: ./.github/actions/yarn-nm-install
         with:
-          cwd: "./js"
+          cwd: "."
           prevent-lock-update: false
 
       - name: "Commit and push changes if modified"

--- a/.github/workflows/test-release-sync.yaml
+++ b/.github/workflows/test-release-sync.yaml
@@ -11,7 +11,46 @@ on:
       - "**"
 
 jobs:
+  update-lock-file:
+    runs-on: "ubuntu-22.04"
+    outputs:
+      VERIFIED_LOCK_COMMIT: ${{ steps.sync-lock-file.outputs.VERIFIED_LOCK_COMMIT }}
+    # Only ever update lock file for PRs
+    if: "github.event_name == 'pull_request'"
+    steps:
+      - name: "Checkout"
+        uses: "actions/checkout@v3"
+        with:
+          ref: ${{ github.head_ref }}
+          fetch-depth: 2
+
+      - name: "Setup Node"
+        uses: "actions/setup-node@v3"
+        with:
+          node-version-file: "js/.nvmrc"
+
+      - name: "Install dependencies with yarn cache"
+        uses: ./.github/actions/yarn-nm-install
+        with:
+          cwd: "./js"
+          prevent-lock-update: false
+
+      - name: "Commit and push changes if modified"
+        id: sync-lock-file
+        run: |
+          git config --global user.name 'Lightspark Eng'
+          git config --global user.email 'engineering@lightspark.com'
+          git add -A
+          git diff-index --quiet HEAD || git commit -nm "CI update lock file for PR"
+          git push
+          echo "$(git rev-parse HEAD)"
+          echo "VERIFIED_LOCK_COMMIT=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
+
   checks:
+    # Wait to see if the lock file should be updated before running checks:
+    needs: "update-lock-file"
+    # Needed when depending on a conditional job (update-lock-file) https://bit.ly/440oM7G
+    if: "always()"
     runs-on: "ubuntu-22.04"
     steps:
       - name: "Checkout"
@@ -54,6 +93,10 @@ jobs:
   # turbo doesn't seem to parallelize builds with checks although they don't depend on one another,
   # or else there's something in CI that prevents it from doing it well. Faster to keep them separate.
   build:
+    # Wait to see if the lock file should be updated before running checks:
+    needs: "update-lock-file"
+    # Needed when depending on a conditional job (update-lock-file) https://bit.ly/440oM7G
+    if: "always()"
     runs-on: "ubuntu-22.04"
     steps:
       - name: "Checkout"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3860,7 +3860,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@lightsparkdev/lightspark-sdk@0.3.3, @lightsparkdev/lightspark-sdk@workspace:packages/lightspark-sdk":
+"@lightsparkdev/lightspark-sdk@0.3.4, @lightsparkdev/lightspark-sdk@workspace:packages/lightspark-sdk":
   version: 0.0.0-use.local
   resolution: "@lightsparkdev/lightspark-sdk@workspace:packages/lightspark-sdk"
   dependencies:
@@ -3973,7 +3973,7 @@ __metadata:
     "@emotion/react": ^11.11.0
     "@emotion/styled": ^11.11.0
     "@lightsparkdev/core": 0.3.2
-    "@lightsparkdev/lightspark-sdk": 0.3.3
+    "@lightsparkdev/lightspark-sdk": 0.3.4
     "@pmmmwh/react-refresh-webpack-plugin": ^0.5.3
     "@svgr/webpack": ^7.0.0
     "@types/chrome": ^0.0.227


### PR DESCRIPTION
The yarn cache task provides a useful option to fail if installing the
deps would modify the lock file. This prevents CI from running against
different deps than what is explicit in the lock file and what we run
locally.

We have a couple scenarios where this causes frequent CI failures. It
happens in webdev PRs when the public js-sdk repo pushes package.json
changes due to new versions published from there. We can't copy over the
yarn.lock from the public repo - we have private deps in webdev that
don't exist in the public repo.

This PR updates the lock file automatically on PRs only - we still want
to fail on main if a change is made that would update the lock file
because it indicates that the tests haven't actually run correctly.