### PR TITLE
Test: enable destination rebase for copybara webdev sync

### DIFF
--- a/.github/workflows/test-release-sync.yaml
+++ b/.github/workflows/test-release-sync.yaml
@@ -255,7 +255,7 @@ jobs:
 
   create-webdev-pr:
     name: Create Webdev PR
-    if: "github.event_name == 'push'"
+    if: "github.event_name == 'push' || github.event_name == 'pull_request'"
     runs-on: "ubuntu-22.04"
     environment: npm
     permissions:
@@ -267,6 +267,7 @@ jobs:
           fetch-depth: 0
 
       - name: Reset develop to main
+        if: "github.event_name == 'push'"
         run: |
           git checkout develop
           git reset --hard origin/main
@@ -317,7 +318,7 @@ jobs:
 
           curl https://lsdev-repo.s3-us-west-2.amazonaws.com/github-actions/copybara_deploy.jar --output ./copybara.jar
           trap on_exit EXIT
-          java -jar copybara.jar ./copy.bara.sky js-sdk-push-to-webdev --nogit-destination-rebase
+          java -jar copybara.jar ./copy.bara.sky js-sdk-push-to-webdev
 
       - name: "Notify failure on Slack"
         if: "failure() && github.event_name == 'push'"


### PR DESCRIPTION
## Summary
- Removes `--nogit-destination-rebase` flag from the copybara sync to webdev
- Temporarily enables the `create-webdev-pr` job on PRs so we can test the copybara flow without merging to main

## Context
The `--nogit-destination-rebase` flag was originally added to avoid merge conflicts when copybara rebases onto webdev main. However, the conflicts were likely from CHANGELOG files, which only change in the public repo — so there shouldn't actually be conflicts during rebase.

Without this flag, copybara automatically rebases the sync commit onto current webdev main, which eliminates the stale PR branch problem we've been hitting (see lightsparkdev/webdev#25478).

## Test plan
- [ ] Open this PR and let the `create-webdev-pr` job run
- [ ] Verify copybara successfully creates/updates the webdev sync PR with destination rebase enabled
- [ ] Check that no merge conflicts occur during the rebase
- [ ] If successful, merge this to enable destination rebase permanently

🤖 Generated with [Claude Code](https://claude.com/claude-code)