### PR TITLE
Test sync

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,3 +26,5 @@ yarn start remote-signing-server
 ```
 
 Please see the README files in the [examples directory](./apps/examples) for instructions on running the examples. Please note that some packages such as @lightsparkdev/ui are for building the examples only and not necessary for your implementation of our [published SDK packages](https://www.npmjs.com/search?q=%40lightsparkdev).
+
+<!-- webdev-sync-refresh-test: 2026-04-29 -->


### PR DESCRIPTION
Temporary validation PR for the js-sdk to webdev Copybara sync refresh path.

This intentionally makes a harmless README-only change on js-sdk main. After merge, the normal production Copybara workflow should run from js-sdk main and update the existing webdev sync PR from latest webdev main.

Expected cleanup: revert/remove this marker after validation if we do not want to keep it permanently.