### PR TITLE
[gha] Fix Copybara app token permissions

### DIFF
--- a/.github/workflows/test-release-sync.yaml
+++ b/.github/workflows/test-release-sync.yaml
@@ -335,9 +335,8 @@ jobs:
           repositories: |
             js-sdk
             webdev
-          permissions: |
-            contents: write
-            workflows: write
+          permission-contents: write
+          permission-pull-requests: write
 
       - name: "Run Copybara"
         env:


### PR DESCRIPTION
## Summary

Fix the Copybara GitHub App token request in the release sync workflow by using the `actions/create-github-app-token@v2` `permission-*` inputs instead of the ignored multiline `permissions` input.

This requests the least privilege we need for the current workflow: `contents: write` for the destination branch push and `pull-requests: write` for PR operations. It intentionally does not request `workflows: write`.

## Testing

- `git diff --check`
- Verified `permission-contents` and `permission-pull-requests` exist in the v2 action metadata via `gh api repos/actions/create-github-app-token/contents/action.yml?ref=v2`

## Notes

If the main-branch Copybara run still hits GitHub workflow-file pre-receive checks, the next fix should be to avoid having Copybara force-update the destination PR branch across webdev main history, not to grant Workflows write permission to this app.