### PR TITLE
[gha] Use per-commit webdev sync branches

### DIFF
--- a/.github/workflows/test-release-sync.yaml
+++ b/.github/workflows/test-release-sync.yaml
@@ -368,7 +368,7 @@ jobs:
 
           curl https://lsdev-repo.s3-us-west-2.amazonaws.com/github-actions/copybara_deploy.jar --output ./copybara.jar
           trap on_exit EXIT
-          java -jar copybara.jar ./copy.bara.sky js-sdk-push-to-webdev --nogit-destination-rebase
+          java -jar copybara.jar ./copy.bara.sky js-sdk-push-to-webdev "${GITHUB_SHA}" --nogit-destination-rebase --github-destination-pr-branch="js-sdk-sync-${GITHUB_SHA}"
 
       - name: "Notify failure on Slack"
         if: "failure() && github.event_name == 'push'"


### PR DESCRIPTION
## Summary

Make the js-sdk to webdev Copybara sync publish to a commit-specific destination PR branch instead of reusing the same generated webdev branch forever.

The workflow now passes the triggering `GITHUB_SHA` as Copybara's source ref and uses `--github-destination-pr-branch=js-sdk-sync-${GITHUB_SHA}`. That keeps the migrated source revision and destination branch identity aligned while avoiding force-pushes over the old stale webdev sync PR branch.

## Testing

- `git diff --check`
- `java -jar /tmp/copybara.jar --output-root=/tmp/copybara-validate validate copy.bara.sky js-sdk-push-to-webdev`
- `java -jar /tmp/copybara.jar --output-root=/tmp/copybara-dryrun --dry-run ./copy.bara.sky js-sdk-push-to-webdev f51579a49914cdaaf217799be1ffdc5e7245917a --nogit-destination-rebase --github-destination-pr-branch=js-sdk-sync-f51579a49914cdaaf217799be1ffdc5e7245917a`

## Notes

This intentionally keeps the branch-name override in the workflow CLI rather than `copy.bara.sky`; the config-level `pr_branch` template requires origin context support that this workflow did not provide in local dry-run validation.