### PR TITLE
[gha] Disable webdev push sync

### DIFF
--- a/.github/workflows/test-release-sync.yaml
+++ b/.github/workflows/test-release-sync.yaml
@@ -307,7 +307,9 @@ jobs:
 
   create-webdev-pr:
     name: Create Webdev PR
-    if: "github.event_name == 'push'"
+    # Webdev now owns pulling public js-sdk changes via its scheduled/manual
+    # Copybara workflow.
+    if: ${{ false }}
     runs-on: "ubuntu-22.04"
     environment: npm
     permissions:


### PR DESCRIPTION
Disables the js-sdk-side job that creates webdev sync PRs. Webdev will own pulling public js-sdk changes via its scheduled/manual Copybara workflow instead, so the destination repo controls rebasing against latest `main`.

Tested with YAML parsing and `git diff --check HEAD~1..HEAD`.
