### PR TITLE
Fix fail-open async UMA validation checks

### DIFF
--- a/apps/examples/uma-vasp/src/ReceivingVasp.ts
+++ b/apps/examples/uma-vasp/src/ReceivingVasp.ts
@@ -164,10 +164,10 @@ export default class ReceivingVasp {
       );
     }
     if (
-      !this.complianceService.shouldAcceptTransactionFromVasp(
+      !(await this.complianceService.shouldAcceptTransactionFromVasp(
         umaQuery.vaspDomain!,
         umaQuery.receiverAddress,
-      )
+      ))
     ) {
       throw new uma.UmaError(
         "This user is not allowed to transact with this VASP.",

--- a/apps/examples/uma-vasp/src/SendingVasp.ts
+++ b/apps/examples/uma-vasp/src/SendingVasp.ts
@@ -194,11 +194,11 @@ export default class SendingVasp {
     }
 
     if (
-      !this.complianceService.shouldAcceptTransactionToVasp(
+      !(await this.complianceService.shouldAcceptTransactionToVasp(
         receivingVaspDomain,
         user.umaUserName,
         receiverUmaAddress,
-      )
+      ))
     ) {
       throw new uma.UmaError(
         `Transaction not allowed to ${receiverUmaAddress}.`,
@@ -481,12 +481,12 @@ export default class SendingVasp {
       amountValueMillisats / sendingCurrency.multiplier;
 
     if (
-      !this.checkInternalLedgerBalance(
+      !(await this.checkInternalLedgerBalance(
         user.id,
         amountValueMillisats,
         sendingCurrencyAmount,
         sendingCurrencyCode,
-      )
+      ))
     ) {
       throw new uma.UmaError(
         "Insufficient balance.",
@@ -930,12 +930,12 @@ export default class SendingVasp {
     }
 
     if (
-      !this.checkInternalLedgerBalance(
+      !(await this.checkInternalLedgerBalance(
         user.id,
         amountMsats,
         sendingCurrencyAmount,
         sendingCurrencyCode,
-      )
+      ))
     ) {
       throw new uma.UmaError(
         "Insufficient balance.",


### PR DESCRIPTION
## Summary
- add missing `await` to async compliance check in `SendingVasp.handleClientUmaLookup`
- add missing `await` to async balance checks in `SendingVasp.handleClientUmaPayreq` and `SendingVasp.handleClientSendPayment`
- add missing `await` to async compliance check in `ReceivingVasp.handleUmaLnurlp`

## Why
These guards call methods returning `Promise<boolean>`. Without `await`, the Promise object is always truthy and can cause fail-open behavior.

## Validation
- `npx -y yarn workspace @lightsparkdev/uma-vasp build`